### PR TITLE
Implement KCLWorkerRunner.shutdown()

### DIFF
--- a/akka/src/main/scala/com/gilt/gfc/aws/kinesis/akka/KinesisStreamHandler.scala
+++ b/akka/src/main/scala/com/gilt/gfc/aws/kinesis/akka/KinesisStreamHandler.scala
@@ -1,7 +1,7 @@
 package com.gilt.gfc.aws.kinesis.akka
 
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer
-import com.amazonaws.services.kinesis.clientlibrary.types.ShutdownReason
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason
 import com.amazonaws.services.kinesis.model.Record
 import com.gilt.gfc.aws.kinesis.client.KinesisRecordReader
 

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ lazy val client = (project in file("client"))
     "com.gilt"      %% "gfc-logging"           % "0.0.7",
     "com.gilt"      %% "gfc-concurrent"        % "0.3.5",
     "com.amazonaws" %  "aws-java-sdk-kinesis"  % "1.11.18",
-    "com.amazonaws" %  "amazon-kinesis-client" % "1.7.0",
+    "com.amazonaws" %  "amazon-kinesis-client" % "1.7.3",
     "org.specs2"    %% "specs2-scalacheck"     % "3.8.6" % Test
   )
 )

--- a/client/src/main/scala/com/gilt/gfc/aws/kinesis/client/KCLRecordProcessorFactory.scala
+++ b/client/src/main/scala/com/gilt/gfc/aws/kinesis/client/KCLRecordProcessorFactory.scala
@@ -3,7 +3,7 @@ package com.gilt.gfc.aws.kinesis.client
 import java.{util => jul}
 
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.{IRecordProcessor, IRecordProcessorCheckpointer, IRecordProcessorFactory}
-import com.amazonaws.services.kinesis.clientlibrary.types.ShutdownReason
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason
 import com.amazonaws.services.kinesis.model.Record
 import com.gilt.gfc.logging.Loggable
 import com.gilt.gfc.util.Retry

--- a/client/src/main/scala/com/gilt/gfc/aws/kinesis/client/KCLWorkerRunner.scala
+++ b/client/src/main/scala/com/gilt/gfc/aws/kinesis/client/KCLWorkerRunner.scala
@@ -3,7 +3,7 @@ package com.gilt.gfc.aws.kinesis.client
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorFactory
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{KinesisClientLibConfiguration, Worker}
-import com.amazonaws.services.kinesis.clientlibrary.types.ShutdownReason
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason
 import com.amazonaws.services.kinesis.metrics.interfaces.IMetricsFactory
 import com.amazonaws.services.kinesis.model.Record
 import com.gilt.gfc.logging.Loggable

--- a/client/src/main/scala/com/gilt/gfc/aws/kinesis/client/KCLWorkerRunner.scala
+++ b/client/src/main/scala/com/gilt/gfc/aws/kinesis/client/KCLWorkerRunner.scala
@@ -8,6 +8,8 @@ import com.amazonaws.services.kinesis.metrics.interfaces.IMetricsFactory
 import com.amazonaws.services.kinesis.model.Record
 import com.gilt.gfc.logging.Loggable
 
+import java.util.concurrent.TimeUnit
+
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.language.postfixOps
@@ -36,6 +38,8 @@ case class KCLWorkerRunner (
 , initialRetryDelay: Duration = 10 seconds
 , maxRetryDelay: FiniteDuration = 3 minutes
 ) extends Loggable {
+
+  private[this] var workers = List[Worker]()
 
   /** Override default checkpointInterval. */
   def withCheckpointInterval( cpi: FiniteDuration
@@ -73,6 +77,25 @@ case class KCLWorkerRunner (
   }
 
   /**
+   * Request graceful shutdown of all Kinesis workers.
+   *
+   * @param callbackTimeout   how long to wait for shutdown to complete
+   */
+  def shutdown(timeout: Duration = 1.minute): Unit = {
+    val javaFutures = synchronized {
+      val r = workers.map(_.requestShutdown)
+      workers = Nil
+      r
+    }
+    if (timeout.isFinite) {
+      val endTime = System.nanoTime + timeout.toNanos
+      javaFutures.foreach(_.get(endTime - System.nanoTime, TimeUnit.NANOSECONDS))
+    } else {
+      javaFutures.foreach(_.get)
+    }
+  }
+
+  /**
    * Run KCL worker with the given callback.
    *
    * @param processRecords     (ShardId, Records, Checkpointer) => Unit : Kinesis record handler
@@ -105,6 +128,9 @@ case class KCLWorkerRunner (
         new Worker(recordProcessorFactory, config))(
         mf => new Worker(recordProcessorFactory, config, mf))
 
+      synchronized {
+        workers ::= worker
+      }
       worker.run()
 
     } catch {


### PR DESCRIPTION
This creates a new `KCLWorkerRunner.getWorkers` method, exposing the kinesis workers created. It also upgrades the amazon-kinesis-client dependency from 1.7.0 to 1.7.3, which introduced a `Worker.requestShutdown` method in 1.7.1.

With both of these changes, it's possible to gracefully shut down the kinesis client before shutting down the app. For example, in an app I'm building, I now use some code like this at startup:

```scala
Runtime.getRuntime.addShutdownHook(new Thread {
  override def run(): Unit = {
    runner.getWorkers.map(_.requestShutdown).foreach(_.get)
    otherCleanup()
  }
})
```