### PR TITLE
Allow setting a region name programatically

### DIFF
--- a/akka/src/main/scala/com/gilt/gfc/aws/kinesis/akka/KinesisStreamConsumer.scala
+++ b/akka/src/main/scala/com/gilt/gfc/aws/kinesis/akka/KinesisStreamConsumer.scala
@@ -13,7 +13,8 @@ class KinesisStreamConsumer[T](
     streamConfig.streamName,
     streamConfig.kinesisCredentialsProvider,
     streamConfig.dynamoCredentialsProvider,
-    streamConfig.cloudWatchCredentialsProvider
+    streamConfig.cloudWatchCredentialsProvider,
+    streamConfig.regionName
   )
 
   private def createWorker = KCLWorkerRunner(

--- a/akka/src/main/scala/com/gilt/gfc/aws/kinesis/akka/KinesisStreamConsumerConfig.scala
+++ b/akka/src/main/scala/com/gilt/gfc/aws/kinesis/akka/KinesisStreamConsumerConfig.scala
@@ -16,7 +16,8 @@ case class KinesisStreamConsumerConfig[T](
   metricsFactory: IMetricsFactory = new NullMetricsFactory(),
   checkPointInterval: FiniteDuration = 5.minutes,
   retryConfig: RetryConfig = RetryConfig(1.second, 1.second, 3),
-  initialPositionInStream: InitialPositionInStream = InitialPositionInStream.LATEST
+  initialPositionInStream: InitialPositionInStream = InitialPositionInStream.LATEST,
+  regionName: Option[String] = None
 ) {
 
   /**

--- a/client/src/main/scala/com/gilt/gfc/aws/kinesis/client/KCLConfiguration.scala
+++ b/client/src/main/scala/com/gilt/gfc/aws/kinesis/client/KCLConfiguration.scala
@@ -35,6 +35,7 @@ object KCLConfiguration {
            , kinesisCredentialsProvider: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain()
            , dynamoCredentialsProvider: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain()
            , cloudWatchCredentialsProvider: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain()
+           , regionName: Option[String] = None
            ): KinesisClientLibConfiguration = {
 
     new KinesisClientLibConfiguration(
@@ -46,6 +47,6 @@ object KCLConfiguration {
     , dynamoCredentialsProvider
     , cloudWatchCredentialsProvider
     , s"${HostName}:${UUID.randomUUID()}"
-    )
+    ).withRegionName(regionName.orNull)
   }
 }


### PR DESCRIPTION
This PR allows to pass a specific region name to the `KinesisStreamConsumer` as an optional parameter. The change is needed to be able to use the KCL in an AWS region that it's different from the default one: `us-east-1`.

As it's said in this AWS document:
http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-region-selection.html

Automatic region resolution it's only done by the SDK when using the client builders, which the Kinesis Client Library does not use. Deploying an app using the GFC Kinesis integration in a zone like `eu-west-1` shows errors in the like of "stream XXX does not exists on account YYY" when connecting to the stream, which are basically due to the fact that it's defaulting to a region in which the stream wasn't defined.

We have tested this patch in our own AWS setup and we see now how it connects successfully and also creates the DynamoDB table in the appropriate region.