### PR TITLE
Evaluate by-name parameter doInitialize after initializing record handler

### DIFF
--- a/client/src/main/scala/com/gilt/gfc/aws/kinesis/client/KCLRecordProcessorFactory.scala
+++ b/client/src/main/scala/com/gilt/gfc/aws/kinesis/client/KCLRecordProcessorFactory.scala
@@ -87,7 +87,7 @@ object KCLRecordProcessorFactory {
         myShardId = shardId
 
         info(s"Initializing record handler for kinesis shard ${myShardId}")
-        doRetry(doInitialize)
+        doRetry(doInitialize(myShardId))
       }
 
 


### PR DESCRIPTION
Came across this error when trying to override the onInit of the KinesisStreamHandler trait. The function was never being called because its evaluation wasn't being passed down.