### PR TITLE
Fix maven badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gfc-aws-kinesis [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gilt/gfc-aws-kinesis_2.12/badge.svg?style=plastic)](https://maven-badges.herokuapp.com/maven-central/com.gilt/gfc-aws-kinesis_2.12) [![Join the chat at https://gitter.im/gilt/gfc](https://badges.gitter.im/gilt/gfc.svg)](https://gitter.im/gilt/gfc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+# gfc-aws-kinesis [![Maven Central](https://img.shields.io/maven-central/v/com.gilt/gfc-aws-kinesis_2.12.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.gilt%22%20a%3A%22gfc-aws-kinesis_2.12%22) [![Join the chat at https://gitter.im/gilt/gfc](https://badges.gitter.im/gilt/gfc.svg)](https://gitter.im/gilt/gfc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Scala wrapper around AWS Kinesis Client Library. Part of the [Gilt Foundation Classes](https://github.com/gilt?q=gfc).
 


### PR DESCRIPTION
Fixes maven central badge, from:
<img width="694" alt="screen shot 2018-03-28 at 12 56 57" src="https://user-images.githubusercontent.com/1754664/38027518-cdd360fa-3287-11e8-9d14-3b032c2b2be4.png">
to:
<img width="680" alt="screen shot 2018-03-28 at 12 57 25" src="https://user-images.githubusercontent.com/1754664/38027526-d2111464-3287-11e8-8ca8-4145d909243c.png">

Currently used service (maven-badges) is down, and it does not look like it's a temporary problem looking at their issues https://github.com/jirutka/maven-badges/issues

This change takes image from https://shields.io. The only observable difference is that maven-badges was linking directly to the artifact latest version (as it was aware of it), while change in this PR links to search result for `g:"com.gilt" a:"gfc-aws-kinesis_2.12"`

Can be previewed here: https://github.com/mkows/gfc-aws-kinesis