### PR TITLE
Make it possible to have manual checkpointing in the akka streams

### DIFF
--- a/akka/src/main/scala/com/gilt/gfc/aws/kinesis/akka/KinesisStreamConsumerConfig.scala
+++ b/akka/src/main/scala/com/gilt/gfc/aws/kinesis/akka/KinesisStreamConsumerConfig.scala
@@ -16,7 +16,7 @@ case class KinesisStreamConsumerConfig[T](
   dynamoCredentialsProvider: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain(),
   cloudWatchCredentialsProvider: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain(),
   metricsFactory: IMetricsFactory = new NullMetricsFactory(),
-  checkPointInterval: FiniteDuration = 5.minutes,
+  checkPointInterval: Duration = 5.minutes,
   retryConfig: RetryConfig = RetryConfig(1.second, 1.second, 3),
   initialPositionInStream: InitialPositionInStream = InitialPositionInStream.LATEST,
   regionName: Option[String] = None,

--- a/akka/src/main/scala/com/gilt/gfc/aws/kinesis/akka/KinesisStreamSource.scala
+++ b/akka/src/main/scala/com/gilt/gfc/aws/kinesis/akka/KinesisStreamSource.scala
@@ -1,5 +1,6 @@
 package com.gilt.gfc.aws.kinesis.akka
 
+import akka.NotUsed
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.{Source, SourceQueue}
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer
@@ -40,11 +41,44 @@ object KinesisStreamSource {
   ) (
     implicit evReader: KinesisRecordReader[T],
     executionContext: ExecutionContext
-  ) = {
+  ): Source[T, Unit] = {
     Source.queue[T](bufferSize, overflowStrategy)
       .mapMaterializedValue(queue => {
         val consumer = new KinesisStreamConsumer[T](streamConfig, KinesisStreamHandler(pumpKinesisStreamTo(queue, pumpingTimeoutDuration)))
         Future(consumer.run)
+      })
+  }
+
+  /**
+    * Creates a non-materialized akka source connected to Kinesis stream, passing checkpointer object
+    * along with each message received, to be able to manually control when checkpointing happens
+    * It is advised to pass checkpointInterval = Duration.Inf in the streamConfig to avoid clashes
+    * with internal time-based automatic checkpointer
+    * @param streamConfig Configuration of the Kinesis stream to consume
+    * @param pumpingTimeoutDuration Duration that source will wait for the akka stream to process message
+    * @param bufferSize Size of the buffer to hold the incoming messages
+    * @param overflowStrategy What to do with messages that would overflow the buffer e.g. backpressure or drop
+    * @param evReader Deserialization typeclass
+    * @param executionContext The execution context to be used for running the kinesis consumer
+    * @return akka Source that on materialization gets messages from Kinesis stream and pump them through the flow
+    */
+  def withManualCheckpointing[T](
+    streamConfig: KinesisStreamConsumerConfig[T],
+    pumpingTimeoutDuration: Duration = Duration.Inf,
+    bufferSize : Int = 0,
+    overflowStrategy: OverflowStrategy = OverflowStrategy.backpressure
+  ) (
+    implicit evReader: KinesisRecordReader[T],
+    executionContext: ExecutionContext
+  ): Source[(T, IRecordProcessorCheckpointer), Unit] = {
+    Source.queue[(T, IRecordProcessorCheckpointer)](bufferSize, overflowStrategy)
+      .mapMaterializedValue(queue => {
+        val consumer = new KinesisStreamConsumer[T](streamConfig, KinesisStreamHandler {
+          (shardId, message, checkpointer) => queue.offer((message, checkpointer))
+        })
+        Future {
+          consumer.run
+        }
       })
   }
 }

--- a/client/src/main/scala/com/gilt/gfc/aws/kinesis/client/KCLRecordProcessorFactory.scala
+++ b/client/src/main/scala/com/gilt/gfc/aws/kinesis/client/KCLRecordProcessorFactory.scala
@@ -38,7 +38,7 @@ object KCLRecordProcessorFactory {
     * @param initialRetryDelay  the initial failed operation retry delay value, defaults to 10 seconds
     * @param maxRetryDelay      the maximum failed operation retry delay value, defaults to 3 minutes
     */
-  def apply( checkpointInterval: FiniteDuration = 5 minutes
+  def apply( checkpointInterval: Duration = 5 minutes
            , numRetries: Int = 3
            , initialize: (String) => Unit = (_) => ()
            , shutdown: (String, IRecordProcessorCheckpointer, ShutdownReason) => Unit = (_,_,_) => ()
@@ -48,7 +48,7 @@ object KCLRecordProcessorFactory {
            ): IRecordProcessorFactory = {
 
     new IRecordProcessorFactoryImpl(
-      checkpointInterval.toMillis
+      checkpointInterval
     , numRetries
     , initialize
     , shutdown
@@ -60,8 +60,7 @@ object KCLRecordProcessorFactory {
 
   private
   class IRecordProcessorFactoryImpl(
-
-    checkpointIntervalMillis: Long
+    checkpointInterval: Duration
   , numRetries: Int
   , doInitialize: (String) => Unit
   , doShutdown: (String, IRecordProcessorCheckpointer, ShutdownReason) => Unit
@@ -126,7 +125,7 @@ object KCLRecordProcessorFactory {
         }
 
         // Checkpoint periodically
-        if ( System.currentTimeMillis - lastCheckpointTimestamp > checkpointIntervalMillis ) {
+        if ( checkpointInterval.isFinite() &&  System.currentTimeMillis - lastCheckpointTimestamp > checkpointInterval.toMillis ) {
           doRetry{ doCheckpoint(checkpointer) }
         }
       }

--- a/client/src/main/scala/com/gilt/gfc/aws/kinesis/client/KCLWorkerRunner.scala
+++ b/client/src/main/scala/com/gilt/gfc/aws/kinesis/client/KCLWorkerRunner.scala
@@ -30,7 +30,7 @@ import scala.util.{Failure, Success, Try}
 case class KCLWorkerRunner (
   config: KinesisClientLibConfiguration
 , dynamoDBKinesisAdapter: Option[AmazonDynamoDBStreamsAdapterClient] = None
-, checkpointInterval: FiniteDuration = 5 minutes
+, checkpointInterval: Duration = 5 minutes
 , numRetries: Int = 3
 , initialize: (String) => Unit = (_) => ()
 , shutdown: (String, IRecordProcessorCheckpointer, ShutdownReason) => Unit = (_,_,_) => ()
@@ -42,7 +42,7 @@ case class KCLWorkerRunner (
   private[this] var workers = List[Worker]()
 
   /** Override default checkpointInterval. */
-  def withCheckpointInterval( cpi: FiniteDuration
+  def withCheckpointInterval( cpi: Duration
                             ): KCLWorkerRunner = {
 
     this.copy(checkpointInterval = cpi)


### PR DESCRIPTION
Automatic checkpointing creates huge problems when the stream materialized using more then one actor